### PR TITLE
feat: make newsletter output configurable

### DIFF
--- a/.github/workflows/daily-huggingface.yml
+++ b/.github/workflows/daily-huggingface.yml
@@ -29,6 +29,7 @@ jobs:
           MCP_URL: ${{ secrets.MCP_URL }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           NEWSLETTER_TOP_N: "12"
+          NEWSLETTER_OUTPUT_DIR: "${{ github.workspace }}/newsletters"
           TZ: "Asia/Seoul"
         run: |
           python -m app.main
@@ -38,9 +39,6 @@ jobs:
           # 결과 파일명을 파악하려면 동일한 날짜 규칙으로 계산:
           pydate=$(python -c "from datetime import datetime,timezone,timedelta;print(datetime.now(timezone(timedelta(hours=9))).date().isoformat())")
           echo "NEWSLETTER_FILENAME=daily-huggingface-${pydate}.md" >> $GITHUB_ENV
-          # 컨테이너 모드가 아니라서 out 디렉터리 생성 후 복사
-          mkdir -p newsletters
-          mv "/data/daily-huggingface-${pydate}.md" "newsletters/daily-huggingface-${pydate}.md"
 
       - uses: peter-evans/create-pull-request@v6
         with:

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 # app/main.py
 import os
 from datetime import datetime, timezone, timedelta
+from pathlib import Path
 
 from .agent import DailyHuggingFaceAgent
 from .render import render_md
@@ -27,12 +28,13 @@ def main():
     date_str = _today_kst_str()
     filename = f"daily-huggingface-{date_str}.md"
 
-    # 컨테이너 내부 출력 경로
-    out_dir = "/data"
-    os.makedirs(out_dir, exist_ok=True)
-    out_path = os.path.join(out_dir, filename)
+    default_out_dir = Path(__file__).resolve().parents[1] / "newsletters"
+    out_dir_env = os.getenv("NEWSLETTER_OUTPUT_DIR")
+    out_dir = Path(out_dir_env).expanduser() if out_dir_env else default_out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / filename
 
-    render_md(models, datasets, spaces, summaries, date_str=date_str, out_path=out_path)
+    render_md(models, datasets, spaces, summaries, date_str=date_str, out_path=str(out_path))
     print(f"[daily-huggingface] generated {out_path}")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- read the output directory from the NEWSLETTER_OUTPUT_DIR environment variable with a default inside the repo
- update the workflow to set NEWSLETTER_OUTPUT_DIR so generated files land directly in the newsletters folder

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7f0702e08832594e5e9696cff83f1