### PR TITLE
refactor: improve newsletter output configuration

### DIFF
--- a/.github/workflows/daily-huggingface.yml
+++ b/.github/workflows/daily-huggingface.yml
@@ -29,6 +29,7 @@ jobs:
           MCP_URL: ${{ secrets.MCP_URL }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           NEWSLETTER_TOP_N: "12"
+          NEWSLETTER_OUTPUT_DIR: "${{ github.workspace }}/newsletters"
           TZ: "Asia/Seoul"
         run: |
           python -m app.main
@@ -38,9 +39,6 @@ jobs:
           # 결과 파일명을 파악하려면 동일한 날짜 규칙으로 계산:
           pydate=$(python -c "from datetime import datetime,timezone,timedelta;print(datetime.now(timezone(timedelta(hours=9))).date().isoformat())")
           echo "NEWSLETTER_FILENAME=daily-huggingface-${pydate}.md" >> $GITHUB_ENV
-          # 컨테이너 모드가 아니라서 out 디렉터리 생성 후 복사
-          mkdir -p newsletters
-          mv "/data/daily-huggingface-${pydate}.md" "newsletters/daily-huggingface-${pydate}.md"
 
       - uses: peter-evans/create-pull-request@v6
         with:

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ docker build -t daily-huggingface .
 ### 2. 실행
 
 ```bash
-# 결과는 ./out/daily-huggingface-YYYY-MM-DD.md 로 생성
+# 기본 출력 경로는 컨테이너 내부 `/data` (호스트의 `./out` 볼륨)
 mkdir -p out
 docker run --rm \
   -e HF_TOKEN="hf_xxxxxxxxx" \
+  -e NEWSLETTER_OUTPUT_DIR="/data" \
   -v "$(pwd)/out:/data" \
   daily-huggingface
 ```
@@ -37,6 +38,7 @@ docker run --rm \
 ```bash
 docker run --rm \
   -e HF_TOKEN="hf_xxxxxxxxx" \
+  -e NEWSLETTER_OUTPUT_DIR="/data" \
   -v "$(pwd)/out:/data" \
   --entrypoint python \
   daily-huggingface -m app.smoke_test
@@ -69,6 +71,7 @@ Spaces:   6
 | `MCP_URL`          | Hugging Face MCP 서버 `/mcp` 엔드포인트   | 선택 | 없음         |
 | `OPENAI_API_KEY`   | OpenAI API 키 (요약문 생성에 사용)          | 선택 | 없음         |
 | `NEWSLETTER_TOP_N` | 섹션별 항목 수                           | 선택 | 12         |
+| `NEWSLETTER_OUTPUT_DIR` | 뉴스레터 Markdown 파일 저장 경로         | 선택 | `<repo>/newsletters` |
 | `TZ`               | 타임존                                | 선택 | Asia/Seoul |
 
 ---
@@ -86,6 +89,7 @@ services:
       MCP_URL: "${MCP_URL}"
       OPENAI_API_KEY: "${OPENAI_API_KEY}"
       NEWSLETTER_TOP_N: "12"
+      NEWSLETTER_OUTPUT_DIR: "/data"
       TZ: "Asia/Seoul"
     volumes:
       - ./out:/data

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 # app/main.py
 import os
 from datetime import datetime, timezone, timedelta
+from pathlib import Path
 
 from .agent import DailyHuggingFaceAgent
 from .render import render_md
@@ -10,6 +11,25 @@ TOP = int(os.getenv("NEWSLETTER_TOP_N", "12"))
 def _today_kst_str():
     kst = timezone(timedelta(hours=9))
     return datetime.now(tz=kst).date().isoformat()
+
+def _resolve_output_dir(out_dir_env: str | None) -> Path:
+    """Return the configured output directory.
+
+    If ``NEWSLETTER_OUTPUT_DIR`` is set and relative, treat it as relative to the
+    repository root (i.e. alongside this file). Otherwise default to
+    ``<repo>/newsletters``.
+    """
+
+    repo_root = Path(__file__).resolve().parents[1]
+
+    if out_dir_env:
+        candidate = Path(out_dir_env).expanduser()
+        if not candidate.is_absolute():
+            candidate = (repo_root / candidate).resolve()
+        return candidate
+
+    return repo_root / "newsletters"
+
 
 def main():
     agent = DailyHuggingFaceAgent(top_n=TOP)
@@ -27,12 +47,11 @@ def main():
     date_str = _today_kst_str()
     filename = f"daily-huggingface-{date_str}.md"
 
-    # 컨테이너 내부 출력 경로
-    out_dir = "/data"
-    os.makedirs(out_dir, exist_ok=True)
-    out_path = os.path.join(out_dir, filename)
+    out_dir = _resolve_output_dir(os.getenv("NEWSLETTER_OUTPUT_DIR"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / filename
 
-    render_md(models, datasets, spaces, summaries, date_str=date_str, out_path=out_path)
+    render_md(models, datasets, spaces, summaries, date_str=date_str, out_path=str(out_path))
     print(f"[daily-huggingface] generated {out_path}")
 
 if __name__ == "__main__":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       MCP_URL: "${MCP_URL}"             # 예: https://mcp.yourdomain/mcp (없어도 동작)
       OPENAI_API_KEY: "${OPENAI_API_KEY}"  # 요약문 옵션
       NEWSLETTER_TOP_N: "12"
+      NEWSLETTER_OUTPUT_DIR: "/data"
       TZ: "Asia/Seoul"
     volumes:
       - ./out:/data


### PR DESCRIPTION
## Summary
- resolve NEWSLETTER_OUTPUT_DIR against the repository root and keep the default newsletters directory
- document the new output directory behaviour and wire NEWSLETTER_OUTPUT_DIR through docker usage examples

## Testing
- python -m compileall app/main.py

------
https://chatgpt.com/codex/tasks/task_e_68d7f0702e08832594e5e9696cff83f1