### PR TITLE
Prioritize recent Hugging Face content

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# Makes the `app` directory a package for test imports.

--- a/app/agent.py
+++ b/app/agent.py
@@ -1,6 +1,6 @@
 # app/agent.py
 import os, math, json, datetime
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Iterable
 
 from .tools import hf_api
 from .tools import mcp_client as mcp
@@ -18,7 +18,10 @@ def _score(item: Dict[str, Any]) -> float:
     if ts:
         try:
             dt = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
-            days = (datetime.datetime.utcnow().replace(tzinfo=dt.tzinfo) - dt).days
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=datetime.timezone.utc)
+            now = datetime.datetime.now(datetime.timezone.utc)
+            days = (now - dt.astimezone(datetime.timezone.utc)).days
             rec = max(0.0, 1.0 - min(days, 30) / 30.0)
         except:
             pass
@@ -28,11 +31,54 @@ class DailyHuggingFaceAgent:
     def __init__(self, top_n: int = 12):
         self.top_n = top_n
 
+    def _filter_recent(self, items: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Return the top-N items prioritising entries updated within seven days."""
+
+        def _parse_ts(value: Optional[str]) -> Optional[datetime.datetime]:
+            if not value:
+                return None
+            try:
+                if value.endswith("Z"):
+                    value = value.replace("Z", "+00:00")
+                dt = datetime.datetime.fromisoformat(value)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=datetime.timezone.utc)
+                return dt.astimezone(datetime.timezone.utc)
+            except Exception:
+                return None
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        recent: List[Dict[str, Any]] = []
+        stale: List[Dict[str, Any]] = []
+
+        for item in items or []:
+            ts = (
+                item.get("updatedAt")
+                or item.get("lastModified")
+                or item.get("lastModifiedAt")
+                or item.get("createdAt")
+            )
+            dt = _parse_ts(ts)
+            if dt and (now - dt).days <= 7:
+                recent.append(item)
+            else:
+                stale.append(item)
+
+        def _sort(items_list: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+            return sorted(items_list, key=_score, reverse=True)
+
+        ordered: List[Dict[str, Any]] = []
+        ordered.extend(_sort(recent)[: self.top_n])
+        if len(ordered) < self.top_n:
+            needed = self.top_n - len(ordered)
+            ordered.extend(_sort(stale)[:needed])
+        return ordered
+
     # ---- 수집 ----
     def top_models(self) -> List[Dict[str, Any]]:
         # 1) MCP 시도
         try:
-            res = mcp.hub_search(q="*", kind="model", limit=self.top_n * 3)
+            res = mcp.hub_search(q="*", kind="model", limit=self.top_n * 5)
             items = res.get("items", [])
             norm=[]
             for it in items:
@@ -44,34 +90,46 @@ class DailyHuggingFaceAgent:
                     "downloads": it.get("downloads"),
                     "likes": it.get("likes"),
                     "library": it.get("library_name"),
-                    "updatedAt": it.get("lastModified")
+                    "updatedAt": it.get("lastModified") or it.get("updatedAt"),
+                    "createdAt": it.get("createdAt"),
                 })
             if norm:
-                norm.sort(key=_score, reverse=True)
-                return norm[:self.top_n]
+                filtered = self._filter_recent(norm)
+                if filtered:
+                    return filtered[: self.top_n]
         except Exception:
             pass
         # 2) 폴백: REST
-        raw = hf_api.top_models_by_downloads(top=self.top_n)
-        return hf_api.normalize_items(raw, id_key="modelId")
+        raw = hf_api.top_models_by_downloads(limit=self.top_n * 5)
+        norm = hf_api.normalize_items(raw, id_key="modelId")
+        filtered = self._filter_recent(norm)
+        return filtered[: self.top_n]
 
     def trending_datasets(self) -> List[Dict[str, Any]]:
         # 1) 트렌딩 시도
-        raw = hf_api.trending("dataset", top=self.top_n)
+        raw = hf_api.trending("dataset", limit=self.top_n * 5)
         if raw:
-            return hf_api.normalize_items(raw, id_key="id")
+            norm = hf_api.normalize_items(raw, id_key="id")
+            filtered = self._filter_recent(norm)
+            if filtered:
+                return filtered[: self.top_n]
         # 2) 폴백: 다운로드 정렬
-        alt = hf_api.top_datasets_by_downloads(top=self.top_n)
-        return hf_api.normalize_items(alt, id_key="id")
+        alt = hf_api.top_datasets_by_downloads(limit=self.top_n * 5)
+        norm_alt = hf_api.normalize_items(alt, id_key="id")
+        return self._filter_recent(norm_alt)[: self.top_n]
 
     def trending_spaces(self) -> List[Dict[str, Any]]:
         # 1) 트렌딩 시도
-        raw = hf_api.trending("space", top=self.top_n)
+        raw = hf_api.trending("space", limit=self.top_n * 5)
         if raw:
-            return hf_api.normalize_items(raw, id_key="id")
+            norm = hf_api.normalize_items(raw, id_key="id")
+            filtered = self._filter_recent(norm)
+            if filtered:
+                return filtered[: self.top_n]
         # 2) 폴백: 좋아요 정렬
-        alt = hf_api.top_spaces_by_likes(top=self.top_n)
-        return hf_api.normalize_items(alt, id_key="id")
+        alt = hf_api.top_spaces_by_likes(limit=self.top_n * 5)
+        norm_alt = hf_api.normalize_items(alt, id_key="id")
+        return self._filter_recent(norm_alt)[: self.top_n]
 
 
     # ---- 요약(옵션) ----

--- a/app/tests/test_recency_filter.py
+++ b/app/tests/test_recency_filter.py
@@ -1,0 +1,132 @@
+import datetime
+
+import pytest
+
+from app.agent import DailyHuggingFaceAgent
+
+
+def _iso_days_ago(days: int) -> str:
+    dt = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=days)
+    return dt.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@pytest.fixture
+def agent(monkeypatch):
+    # Ensure MCP lookup does not interfere with tests
+    monkeypatch.setattr("app.agent.mcp.hub_search", lambda **kwargs: {"items": []})
+    return DailyHuggingFaceAgent(top_n=3)
+
+
+def test_top_models_prefers_recent(monkeypatch, agent):
+    now_items = [
+        {
+            "modelId": "fresh-1",
+            "downloads": 1000,
+            "likes": 200,
+            "lastModified": _iso_days_ago(0),
+        },
+        {
+            "modelId": "fresh-2",
+            "downloads": 900,
+            "likes": 150,
+            "lastModified": _iso_days_ago(2),
+        },
+        {
+            "modelId": "fresh-3",
+            "downloads": 800,
+            "likes": 100,
+            "lastModified": _iso_days_ago(3),
+        },
+        {
+            "modelId": "stale-1",
+            "downloads": 5000,
+            "likes": 500,
+            "lastModified": _iso_days_ago(10),
+        },
+    ]
+
+    monkeypatch.setattr(
+        "app.tools.hf_api.top_models_by_downloads", lambda limit=36: now_items
+    )
+
+    results = agent.top_models()
+    ids = [item["id"] for item in results]
+
+    assert ids == ["fresh-1", "fresh-2", "fresh-3"]
+
+
+def test_trending_datasets_falls_back_to_stale_only_when_needed(monkeypatch, agent):
+    items = [
+        {
+            "id": "recent-a",
+            "downloads": 2000,
+            "likes": 150,
+            "lastModified": _iso_days_ago(1),
+        },
+        {
+            "id": "recent-b",
+            "downloads": 1500,
+            "likes": 120,
+            "lastModified": _iso_days_ago(6),
+        },
+        {
+            "id": "stale-a",
+            "downloads": 9000,
+            "likes": 900,
+            "lastModified": _iso_days_ago(12),
+        },
+        {
+            "id": "stale-b",
+            "downloads": 8000,
+            "likes": 800,
+            "lastModified": _iso_days_ago(15),
+        },
+    ]
+
+    def fake_trending(kind: str, limit: int = 12):
+        assert kind == "dataset"
+        assert limit >= 3 * 5
+        return items
+
+    monkeypatch.setattr("app.tools.hf_api.trending", fake_trending)
+    monkeypatch.setattr(
+        "app.tools.hf_api.top_datasets_by_downloads",
+        lambda limit=36: pytest.fail("fallback should not be used when trending returns data"),
+    )
+
+    results = agent.trending_datasets()
+    ids = [item["id"] for item in results]
+
+    assert ids[:2] == ["recent-a", "recent-b"]
+    # only one stale item should be used to fill the remaining slot
+    assert ids[2] in {"stale-a", "stale-b"}
+
+
+def test_trending_spaces_uses_stale_when_no_recent(monkeypatch, agent):
+    items = [
+        {
+            "id": "stale-one",
+            "downloads": 4000,
+            "likes": 400,
+            "lastModified": _iso_days_ago(20),
+        },
+        {
+            "id": "stale-two",
+            "downloads": 3500,
+            "likes": 300,
+            "lastModified": _iso_days_ago(30),
+        },
+    ]
+
+    monkeypatch.setattr(
+        "app.tools.hf_api.trending", lambda kind, limit=12: items if kind == "space" else []
+    )
+    monkeypatch.setattr(
+        "app.tools.hf_api.top_spaces_by_likes",
+        lambda limit=36: items,
+    )
+
+    results = agent.trending_spaces()
+    ids = [item["id"] for item in results]
+
+    assert ids == ["stale-one", "stale-two"]


### PR DESCRIPTION
## Summary
- add a recency-aware filter that prioritizes items updated in the last week while filling with older entries when necessary
- over-fetch Hugging Face API results and propagate timestamp fields needed for recency filtering
- cover the new selection logic with regression tests that mock API responses

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d8759f001c83258e0476f441bb915f