### PR TITLE
Handle Hugging Face API HTTP errors

### DIFF
--- a/app/tests/test_hf_api_fallbacks.py
+++ b/app/tests/test_hf_api_fallbacks.py
@@ -1,0 +1,109 @@
+import datetime
+from typing import Optional
+
+import pytest
+import requests
+
+from app.agent import DailyHuggingFaceAgent
+
+
+class DummyResponse:
+    def __init__(self, payload=None, error: Optional[Exception] = None):
+        self._payload = payload
+        self._error = error
+
+    def raise_for_status(self):
+        if self._error:
+            raise self._error
+
+    def json(self):
+        return self._payload
+
+
+def _iso_now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@pytest.fixture
+def agent(monkeypatch):
+    monkeypatch.setattr("app.agent.mcp.hub_search", lambda **kwargs: {"items": []})
+    return DailyHuggingFaceAgent(top_n=2)
+
+
+def test_top_models_recovers_when_recent_models_http_error(monkeypatch, agent):
+    def fake_get(url, **kwargs):
+        params = kwargs.get("params", {})
+        if url.endswith("/api/models") and params.get("sort") == "last_modified":
+            return DummyResponse(error=requests.HTTPError("recent models boom"))
+        if url.endswith("/api/models") and params.get("sort") == "downloads":
+            return DummyResponse(
+                payload=[
+                    {
+                        "modelId": "download-fallback",
+                        "downloads": 123,
+                        "likes": 45,
+                        "lastModified": _iso_now(),
+                    }
+                ]
+            )
+        raise AssertionError("unexpected request: %s %s" % (url, params))
+
+    monkeypatch.setattr("app.tools.hf_api.requests.get", fake_get)
+
+    results = agent.top_models()
+
+    assert [item["id"] for item in results] == ["download-fallback"]
+
+
+def test_trending_datasets_recovers_when_recent_http_error(monkeypatch, agent):
+    monkeypatch.setattr("app.tools.hf_api.trending", lambda kind, limit=12: [])
+
+    def fake_get(url, **kwargs):
+        params = kwargs.get("params", {})
+        if url.endswith("/api/datasets") and params.get("sort") == "last_modified":
+            return DummyResponse(error=requests.HTTPError("recent datasets boom"))
+        if url.endswith("/api/datasets") and params.get("sort") == "downloads":
+            return DummyResponse(
+                payload=[
+                    {
+                        "id": "dataset-fallback",
+                        "downloads": 999,
+                        "likes": 88,
+                        "lastModified": _iso_now(),
+                    }
+                ]
+            )
+        raise AssertionError("unexpected request: %s %s" % (url, params))
+
+    monkeypatch.setattr("app.tools.hf_api.requests.get", fake_get)
+
+    results = agent.trending_datasets()
+
+    assert [item["id"] for item in results] == ["dataset-fallback"]
+
+
+def test_trending_spaces_recovers_when_recent_http_error(monkeypatch, agent):
+    monkeypatch.setattr("app.tools.hf_api.trending", lambda kind, limit=12: [])
+
+    def fake_get(url, **kwargs):
+        params = kwargs.get("params", {})
+        if url.endswith("/api/spaces") and params.get("sort") == "last_modified":
+            return DummyResponse(error=requests.HTTPError("recent spaces boom"))
+        if url.endswith("/api/spaces") and params.get("sort") == "likes":
+            return DummyResponse(
+                payload=[
+                    {
+                        "id": "space-fallback",
+                        "downloads": 10,
+                        "likes": 500,
+                        "lastModified": _iso_now(),
+                    }
+                ]
+            )
+        raise AssertionError("unexpected request: %s %s" % (url, params))
+
+    monkeypatch.setattr("app.tools.hf_api.requests.get", fake_get)
+
+    results = agent.trending_spaces()
+
+    assert [item["id"] for item in results] == ["space-fallback"]

--- a/app/tools/hf_api.py
+++ b/app/tools/hf_api.py
@@ -1,10 +1,13 @@
 # app/tools/hf_api.py
+import logging
 import os
 import requests
 from typing import List, Dict, Any
 
 BASE = "https://huggingface.co"
 HF_TOKEN = os.getenv("HF_TOKEN", "").strip()
+
+logger = logging.getLogger(__name__)
 
 def _headers():
     return {"Authorization": f"Bearer {HF_TOKEN}"} if HF_TOKEN else {}
@@ -25,61 +28,117 @@ def trending(kind: str, limit: int = 12) -> List[Dict[str, Any]]:
             if "lastModified" not in item and "lastModifiedAt" in item:
                 item["lastModified"] = item.get("lastModifiedAt")
         return data[:limit]
-    except requests.HTTPError:
+    except requests.HTTPError as err:
+        logger.warning("hf_api.trending(%s) failed: %s", kind, err)
         return []
-    except Exception:
+    except requests.RequestException as err:
+        logger.warning("hf_api.trending(%s) request failed: %s", kind, err)
+        return []
+    except Exception as err:
+        logger.warning("hf_api.trending(%s) unexpected error: %s", kind, err)
         return []
 
 def top_models_by_downloads(limit: int = 12) -> List[Dict[str, Any]]:
-    r = requests.get(f"{BASE}/api/models",
-                     params={"limit": limit, "sort": "downloads"},
-                     headers=_headers(), timeout=45)
-    r.raise_for_status()
-    return r.json() or []
+    try:
+        r = requests.get(
+            f"{BASE}/api/models",
+            params={"limit": limit, "sort": "downloads"},
+            headers=_headers(),
+            timeout=45,
+        )
+        r.raise_for_status()
+        return r.json() or []
+    except requests.HTTPError as err:
+        logger.warning("hf_api.top_models_by_downloads failed: %s", err)
+        return []
+    except requests.RequestException as err:
+        logger.warning("hf_api.top_models_by_downloads request failed: %s", err)
+        return []
 
 def recent_models(limit: int = 12) -> List[Dict[str, Any]]:
-    r = requests.get(
-        f"{BASE}/api/models",
-        params={"limit": limit, "sort": "last_modified", "full": "1"},
-        headers=_headers(),
-        timeout=45,
-    )
-    r.raise_for_status()
-    return r.json() or []
+    try:
+        r = requests.get(
+            f"{BASE}/api/models",
+            params={"limit": limit, "sort": "last_modified", "full": "1"},
+            headers=_headers(),
+            timeout=45,
+        )
+        r.raise_for_status()
+        return r.json() or []
+    except requests.HTTPError as err:
+        logger.warning("hf_api.recent_models failed: %s", err)
+        return []
+    except requests.RequestException as err:
+        logger.warning("hf_api.recent_models request failed: %s", err)
+        return []
 
 def top_datasets_by_downloads(limit: int = 12) -> List[Dict[str, Any]]:
-    r = requests.get(f"{BASE}/api/datasets",
-                     params={"limit": limit, "sort": "downloads"},
-                     headers=_headers(), timeout=45)
-    r.raise_for_status()
-    return r.json() or []
+    try:
+        r = requests.get(
+            f"{BASE}/api/datasets",
+            params={"limit": limit, "sort": "downloads"},
+            headers=_headers(),
+            timeout=45,
+        )
+        r.raise_for_status()
+        return r.json() or []
+    except requests.HTTPError as err:
+        logger.warning("hf_api.top_datasets_by_downloads failed: %s", err)
+        return []
+    except requests.RequestException as err:
+        logger.warning("hf_api.top_datasets_by_downloads request failed: %s", err)
+        return []
 
 def recent_datasets(limit: int = 12) -> List[Dict[str, Any]]:
-    r = requests.get(
-        f"{BASE}/api/datasets",
-        params={"limit": limit, "sort": "last_modified", "full": "1"},
-        headers=_headers(),
-        timeout=45,
-    )
-    r.raise_for_status()
-    return r.json() or []
+    try:
+        r = requests.get(
+            f"{BASE}/api/datasets",
+            params={"limit": limit, "sort": "last_modified", "full": "1"},
+            headers=_headers(),
+            timeout=45,
+        )
+        r.raise_for_status()
+        return r.json() or []
+    except requests.HTTPError as err:
+        logger.warning("hf_api.recent_datasets failed: %s", err)
+        return []
+    except requests.RequestException as err:
+        logger.warning("hf_api.recent_datasets request failed: %s", err)
+        return []
 
 def top_spaces_by_likes(limit: int = 12) -> List[Dict[str, Any]]:
-    r = requests.get(f"{BASE}/api/spaces",
-                     params={"limit": limit, "sort": "likes"},
-                     headers=_headers(), timeout=45)
-    r.raise_for_status()
-    return r.json() or []
+    try:
+        r = requests.get(
+            f"{BASE}/api/spaces",
+            params={"limit": limit, "sort": "likes"},
+            headers=_headers(),
+            timeout=45,
+        )
+        r.raise_for_status()
+        return r.json() or []
+    except requests.HTTPError as err:
+        logger.warning("hf_api.top_spaces_by_likes failed: %s", err)
+        return []
+    except requests.RequestException as err:
+        logger.warning("hf_api.top_spaces_by_likes request failed: %s", err)
+        return []
 
 def recent_spaces(limit: int = 12) -> List[Dict[str, Any]]:
-    r = requests.get(
-        f"{BASE}/api/spaces",
-        params={"limit": limit, "sort": "last_modified", "full": "1"},
-        headers=_headers(),
-        timeout=45,
-    )
-    r.raise_for_status()
-    return r.json() or []
+    try:
+        r = requests.get(
+            f"{BASE}/api/spaces",
+            params={"limit": limit, "sort": "last_modified", "full": "1"},
+            headers=_headers(),
+            timeout=45,
+        )
+        r.raise_for_status()
+        return r.json() or []
+    except requests.HTTPError as err:
+        logger.warning("hf_api.recent_spaces failed: %s", err)
+        return []
+    except requests.RequestException as err:
+        logger.warning("hf_api.recent_spaces request failed: %s", err)
+        return []
 
 def normalize_items(raw, id_key="id"):
     out=[]


### PR DESCRIPTION
## Summary
- add logging-backed HTTP error handling to Hugging Face API helper functions
- ensure helper failures return empty collections so agent fallbacks proceed
- add tests covering HTTP error fallbacks for models, datasets, and spaces

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9d743bef883258e9e9bdd70212ab5