### PR TITLE
Fix Hugging Face trending parsing and prioritise MCP results

### DIFF
--- a/app/tests/test_agent_mcp.py
+++ b/app/tests/test_agent_mcp.py
@@ -1,0 +1,58 @@
+import datetime
+
+from app.agent import DailyHuggingFaceAgent
+
+
+def _iso_now() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def test_trending_datasets_prefers_mcp(monkeypatch):
+    agent = DailyHuggingFaceAgent(top_n=1)
+
+    def fake_hub_search(**kwargs):
+        assert kwargs["kind"] == "dataset"
+        return {
+            "items": [
+                {
+                    "id": "dataset-from-mcp",
+                    "lastModified": _iso_now(),
+                    "likes": 10,
+                    "downloads": 20,
+                }
+            ]
+        }
+
+    monkeypatch.setattr("app.agent.mcp.hub_search", fake_hub_search)
+    monkeypatch.setattr("app.tools.hf_api.trending", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not call REST trending")))
+
+    results = agent.trending_datasets()
+    assert [item["id"] for item in results] == ["dataset-from-mcp"]
+
+
+def test_trending_spaces_prefers_mcp(monkeypatch):
+    agent = DailyHuggingFaceAgent(top_n=1)
+
+    def fake_hub_search(**kwargs):
+        assert kwargs["kind"] == "space"
+        return {
+            "items": [
+                {
+                    "id": "space-from-mcp",
+                    "lastModified": _iso_now(),
+                    "likes": 5,
+                    "downloads": 3,
+                }
+            ]
+        }
+
+    monkeypatch.setattr("app.agent.mcp.hub_search", fake_hub_search)
+    monkeypatch.setattr("app.tools.hf_api.trending", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not call REST trending")))
+
+    results = agent.trending_spaces()
+    assert [item["id"] for item in results] == ["space-from-mcp"]

--- a/app/tests/test_hf_api_fallbacks.py
+++ b/app/tests/test_hf_api_fallbacks.py
@@ -33,7 +33,7 @@ def agent(monkeypatch):
 def test_top_models_recovers_when_recent_models_http_error(monkeypatch, agent):
     def fake_get(url, **kwargs):
         params = kwargs.get("params", {})
-        if url.endswith("/api/models") and params.get("sort") == "last_modified":
+        if url.endswith("/api/models") and params.get("sort") == "lastModified":
             return DummyResponse(error=requests.HTTPError("recent models boom"))
         if url.endswith("/api/models") and params.get("sort") == "downloads":
             return DummyResponse(
@@ -60,7 +60,7 @@ def test_trending_datasets_recovers_when_recent_http_error(monkeypatch, agent):
 
     def fake_get(url, **kwargs):
         params = kwargs.get("params", {})
-        if url.endswith("/api/datasets") and params.get("sort") == "last_modified":
+        if url.endswith("/api/datasets") and params.get("sort") == "lastModified":
             return DummyResponse(error=requests.HTTPError("recent datasets boom"))
         if url.endswith("/api/datasets") and params.get("sort") == "downloads":
             return DummyResponse(
@@ -87,7 +87,7 @@ def test_trending_spaces_recovers_when_recent_http_error(monkeypatch, agent):
 
     def fake_get(url, **kwargs):
         params = kwargs.get("params", {})
-        if url.endswith("/api/spaces") and params.get("sort") == "last_modified":
+        if url.endswith("/api/spaces") and params.get("sort") == "lastModified":
             return DummyResponse(error=requests.HTTPError("recent spaces boom"))
         if url.endswith("/api/spaces") and params.get("sort") == "likes":
             return DummyResponse(

--- a/app/tests/test_hf_api_trending.py
+++ b/app/tests/test_hf_api_trending.py
@@ -1,0 +1,82 @@
+import datetime
+from typing import Any, Optional
+
+import pytest
+
+from app.tools import hf_api
+
+
+class DummyResponse:
+    def __init__(self, payload: Any = None, error: Optional[Exception] = None):
+        self._payload = payload
+        self._error = error
+
+    def raise_for_status(self):
+        if self._error:
+            raise self._error
+
+    def json(self):
+        return self._payload
+
+
+def _iso_now() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def test_trending_handles_dict_payload(monkeypatch):
+    captured_params = {}
+
+    def fake_get(url, **kwargs):
+        assert url.endswith("/api/trending")
+        captured_params.update(kwargs.get("params", {}))
+        return DummyResponse(
+            payload={
+                "datasets": [
+                    {"id": "ds-1", "lastModifiedAt": _iso_now()},
+                    {"id": "ds-2", "lastModifiedAt": _iso_now()},
+                    {"id": "ds-3", "lastModified": _iso_now()},
+                ],
+                "models": [],
+            }
+        )
+
+    monkeypatch.setattr("app.tools.hf_api.requests.get", fake_get)
+
+    results = hf_api.trending("dataset", limit=2)
+
+    assert [item["id"] for item in results] == ["ds-1", "ds-2"]
+    assert captured_params["type"] == "dataset"
+    assert captured_params["limit"] == 2
+    assert all("lastModified" in item for item in results)
+
+
+def _assert_camel_case(monkeypatch, func, endpoint: str):
+    requested_params = []
+
+    def fake_get(url, **kwargs):
+        assert url.endswith(endpoint)
+        requested_params.append(kwargs.get("params", {}))
+        return DummyResponse(payload=[{"id": "ok"}])
+
+    monkeypatch.setattr("app.tools.hf_api.requests.get", fake_get)
+
+    result = func(limit=1)
+    assert result == [{"id": "ok"}]
+    assert requested_params[0]["sort"] == "lastModified"
+
+
+@pytest.mark.parametrize(
+    "func, endpoint",
+    [
+        (hf_api.recent_models, "/api/models"),
+        (hf_api.recent_datasets, "/api/datasets"),
+        (hf_api.recent_spaces, "/api/spaces"),
+    ],
+)
+def test_recent_helpers_use_camel_case(monkeypatch, func, endpoint):
+    _assert_camel_case(monkeypatch, func, endpoint)


### PR DESCRIPTION
## Summary
- normalise /api/trending responses and ensure recent model/dataset/space calls use the camelCase sort flag
- fetch datasets and spaces from MCP before falling back to Hugging Face REST APIs, sharing helper logic with models
- add regression coverage for the trending parser, camelCase parameters, and MCP-first dataset/space flows

## Testing
- `pytest`
- `python -m app.smoke_test` *(fails to reach huggingface.co in CI due to 403 proxy errors, but code paths execute)*

------
https://chatgpt.com/codex/tasks/task_e_68ddba0bd0348325af6c5ec30e06f327