### PR TITLE
ci: create issue instead of pull request in daily-huggingface workflow

### DIFF
--- a/.github/workflows/daily-huggingface.yml
+++ b/.github/workflows/daily-huggingface.yml
@@ -1,4 +1,4 @@
-name: Daily HuggingFace (PR)
+name: Daily HuggingFace (Issue)
 
 on:
   schedule:
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
+      issues: write
 
     steps:
       - uses: actions/checkout@v4
@@ -40,12 +40,49 @@ jobs:
           pydate=$(python -c "from datetime import datetime,timezone,timedelta;print(datetime.now(timezone(timedelta(hours=9))).date().isoformat())")
           echo "NEWSLETTER_FILENAME=daily-huggingface-${pydate}.md" >> $GITHUB_ENV
 
-      - uses: peter-evans/create-pull-request@v6
+      - name: Collect newsletter metadata
+        run: |
+          FILE_PATH="newsletters/${{ env.NEWSLETTER_FILENAME }}"
+          export NEWSLETTER_PATH="${FILE_PATH}"
+          echo "NEWSLETTER_PATH=${FILE_PATH}" >> $GITHUB_ENV
+
+          python - <<'PY'
+          import os
+          import re
+
+          path = os.environ["NEWSLETTER_PATH"]
+          text = open(path, encoding="utf-8").read()
+
+          def section_count(header: str) -> int:
+              match = re.search(rf"^## {re.escape(header)}\n(.*?)(?=^## |\Z)", text, re.M | re.S)
+              if not match:
+                  return 0
+              body = match.group(1)
+              return len(re.findall(r"^- \\[", body, re.M))
+
+          models = section_count("Top Models")
+          datasets = section_count("Trending Datasets")
+          spaces = section_count("Trending Spaces")
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env:
+              env.write(f"MODELS_COUNT={models}\n")
+              env.write(f"DATASETS_COUNT={datasets}\n")
+              env.write(f"SPACES_COUNT={spaces}\n")
+          PY
+
+      - name: Create issue
+        uses: actions/github-script@v7
         with:
-          commit-message: "chore(daily-huggingface): add ${{ env.NEWSLETTER_FILENAME }}"
-          title: "Daily HuggingFace: ${{ env.NEWSLETTER_FILENAME }}"
-          body: "Automated daily newsletter."
-          branch: "chore/dhf/${{ env.NEWSLETTER_FILENAME }}"
-          base: "main"
-          add-paths: |
-            newsletters/${{ env.NEWSLETTER_FILENAME }}
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Daily HuggingFace: ${{ env.NEWSLETTER_FILENAME }}`,
+              body: [
+                'Automated daily newsletter generated.',
+                '',
+                `- 생성된 파일: \\`${{ env.NEWSLETTER_PATH }}\\``,
+                `- 섹션별 아이템 수: models=${{ env.MODELS_COUNT }}, datasets=${{ env.DATASETS_COUNT }}, spaces=${{ env.SPACES_COUNT }}`,
+                '- 후속 액션: 검토 후 수동 merge/commit',
+              ].join('\n'),
+            });


### PR DESCRIPTION
### Motivation

- Convert the workflow from auto-creating a pull request to creating a GitHub Issue so generated newsletters can be reviewed and merged manually. 
- Ensure the workflow reports the generated file path and per-section item counts (models/datasets/spaces) in the issue body for easier review. 
- Replace `peter-evans/create-pull-request@v6` with an issue-based approach and update permissions to allow `issues: write`.

### Description

- Renamed the workflow to `Daily HuggingFace (Issue)` and changed permissions from `pull-requests: write` to `issues: write` in `.github/workflows/daily-huggingface.yml`.
- Removed the `peter-evans/create-pull-request@v6` step and added a `Collect newsletter metadata` step that reads the generated file and sets `MODELS_COUNT`, `DATASETS_COUNT`, and `SPACES_COUNT` in the environment using a small Python parser.
- Added a `Create issue` step using `actions/github-script@v7` which calls `github.rest.issues.create` and includes the generated file path, per-section counts, and a follow-up action note in the issue body.

### Testing

- Ran `git diff --check` to verify patch formatting, which succeeded. 
- Ran `git status --short` to confirm the workflow file was modified, which succeeded. 
- Committed the change with `git commit -m "ci: create issue instead of pull request"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80adcd2948325ae340a607ab94962)