### PR TITLE
Refactor agent collection flow into shared internal helper

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -1,6 +1,6 @@
 # app/agent.py
 import os, math, json, datetime
-from typing import List, Dict, Any, Optional, Iterable, Tuple, Sequence
+from typing import List, Dict, Any, Optional, Iterable, Tuple, Sequence, Callable
 
 from .tools import hf_api
 from .tools import mcp_client as mcp
@@ -142,80 +142,61 @@ class DailyHuggingFaceAgent:
             )
         return normalized
 
+    def _collect_items(
+        self,
+        kind: str,
+        strategies: Sequence[Tuple[Callable[[int], List[Dict[str, Any]]], str]],
+        id_fields: Sequence[str],
+    ) -> List[Dict[str, Any]]:
+        combined = self._collect_from_mcp(kind, id_fields)
+        if combined:
+            filtered = self._filter_recent(combined)
+            if len(filtered) >= self.top_n:
+                return filtered[: self.top_n]
+
+        for fetcher, id_key in strategies:
+            recent_bucket, _ = self._split_recent_stale(combined)
+            if combined and len(combined) >= self.top_n and recent_bucket:
+                continue
+
+            raw = fetcher(self.top_n * 5)
+            normalized = hf_api.normalize_items(raw, id_key=id_key)
+            combined = self._merge_unique(combined, normalized)
+
+        return self._filter_recent(combined)[: self.top_n]
+
     # ---- 수집 ----
     def top_models(self) -> List[Dict[str, Any]]:
-        # 1) MCP 시도
-        combined = self._collect_from_mcp("model", ["id", "modelId"])
-        if combined:
-            filtered = self._filter_recent(combined)
-            if len(filtered) >= self.top_n:
-                return filtered[: self.top_n]
-
-        # 2) 폴백: REST - 최근 정렬 우선
-        recent_raw = hf_api.recent_models(limit=self.top_n * 5)
-        recent_norm = hf_api.normalize_items(recent_raw, id_key="modelId")
-        combined = self._merge_unique(combined, recent_norm) if combined else recent_norm
-        recent_bucket, _ = self._split_recent_stale(combined)
-        if len(combined) < self.top_n or not recent_bucket:
-            downloads_raw = hf_api.top_models_by_downloads(limit=self.top_n * 5)
-            downloads_norm = hf_api.normalize_items(downloads_raw, id_key="modelId")
-            combined = self._merge_unique(combined, downloads_norm)
-        filtered = self._filter_recent(combined)
-        return filtered[: self.top_n]
+        return self._collect_items(
+            kind="model",
+            strategies=[
+                (hf_api.recent_models, "modelId"),
+                (hf_api.top_models_by_downloads, "modelId"),
+            ],
+            id_fields=["id", "modelId"],
+        )
 
     def trending_datasets(self) -> List[Dict[str, Any]]:
-        combined = self._collect_from_mcp("dataset", ["id", "datasetId"])
-        if combined:
-            filtered = self._filter_recent(combined)
-            if len(filtered) >= self.top_n:
-                return filtered[: self.top_n]
-
-        # 1) 트렌딩 시도
-        raw = hf_api.trending("dataset", limit=self.top_n * 5)
-        if raw:
-            trending_norm = hf_api.normalize_items(raw, id_key="id")
-            combined = self._merge_unique(combined, trending_norm) if combined else trending_norm
-
-        recent_bucket, _ = self._split_recent_stale(combined)
-        if len(combined) < self.top_n or not recent_bucket:
-            recent_raw = hf_api.recent_datasets(limit=self.top_n * 5)
-            recent_norm = hf_api.normalize_items(recent_raw, id_key="id")
-            combined = self._merge_unique(combined, recent_norm)
-
-        recent_bucket, _ = self._split_recent_stale(combined)
-        if len(combined) < self.top_n or not recent_bucket:
-            alt = hf_api.top_datasets_by_downloads(limit=self.top_n * 5)
-            norm_alt = hf_api.normalize_items(alt, id_key="id")
-            combined = self._merge_unique(combined, norm_alt)
-
-        return self._filter_recent(combined)[: self.top_n]
+        return self._collect_items(
+            kind="dataset",
+            strategies=[
+                (lambda limit: hf_api.trending("dataset", limit=limit), "id"),
+                (hf_api.recent_datasets, "id"),
+                (hf_api.top_datasets_by_downloads, "id"),
+            ],
+            id_fields=["id", "datasetId"],
+        )
 
     def trending_spaces(self) -> List[Dict[str, Any]]:
-        combined = self._collect_from_mcp("space", ["id", "spaceId"])
-        if combined:
-            filtered = self._filter_recent(combined)
-            if len(filtered) >= self.top_n:
-                return filtered[: self.top_n]
-
-        # 1) 트렌딩 시도
-        raw = hf_api.trending("space", limit=self.top_n * 5)
-        if raw:
-            trending_norm = hf_api.normalize_items(raw, id_key="id")
-            combined = self._merge_unique(combined, trending_norm) if combined else trending_norm
-
-        recent_bucket, _ = self._split_recent_stale(combined)
-        if len(combined) < self.top_n or not recent_bucket:
-            recent_raw = hf_api.recent_spaces(limit=self.top_n * 5)
-            recent_norm = hf_api.normalize_items(recent_raw, id_key="id")
-            combined = self._merge_unique(combined, recent_norm)
-
-        recent_bucket, _ = self._split_recent_stale(combined)
-        if len(combined) < self.top_n or not recent_bucket:
-            alt = hf_api.top_spaces_by_likes(limit=self.top_n * 5)
-            norm_alt = hf_api.normalize_items(alt, id_key="id")
-            combined = self._merge_unique(combined, norm_alt)
-
-        return self._filter_recent(combined)[: self.top_n]
+        return self._collect_items(
+            kind="space",
+            strategies=[
+                (lambda limit: hf_api.trending("space", limit=limit), "id"),
+                (hf_api.recent_spaces, "id"),
+                (hf_api.top_spaces_by_likes, "id"),
+            ],
+            id_fields=["id", "spaceId"],
+        )
 
 
     # ---- 요약(옵션) ----


### PR DESCRIPTION
### Motivation
- 중복된 수집·폴백 로직을 `top_models`, `trending_datasets`, `trending_spaces`에서 공통화해 유지보수성을 향상시키기 위해 `DailyHuggingFaceAgent`에 내부 헬퍼를 도입합니다.
- 기존 흐름(MCP 수집 → 1차 소스 → 2차 폴백 → `_merge_unique`/`_filter_recent`)을 하나의 메서드에서 일관되게 처리하도록 정리하려는 목적입니다.
- 퍼블릭 API는 얇은 래퍼로 남겨 소스 전략만 주입하도록 단순화합니다.

### Description
- 새 내부 메서드 `DailyHuggingFaceAgent._collect_items(kind, strategies, id_fields)`를 추가하여 MCP 수집, 조기 반환(충분한 MCP 결과) 및 전략 기반 단계적 폴백을 중앙화했습니다.
- `top_models`, `trending_datasets`, `trending_spaces`를 각각 `._collect_items(...)` 호출로 축소하고 각 종류별 전략(예: `hf_api.recent_models`, `hf_api.top_models_by_downloads`, `hf_api.trending`)을 주입하도록 변경했습니다.
- 전략 함수 타입 표현을 위해 `Callable`을 타입 힌트에 추가했고, 전략에서 받아온 원시 결과는 기존의 `hf_api.normalize_items`로 정규화하여 `_merge_unique` 및 `_filter_recent`을 적용합니다.
- 기존 MCP 정규화 로직과 점수/필터링 동작은 변경하지 않고 보존했습니다.

### Testing
- 실행한 자동화 테스트: `pytest -q app/tests/test_recency_filter.py app/tests/test_hf_api_fallbacks.py app/tests/test_agent_mcp.py`.
- 결과: 모든 테스트 통과 (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80b968c888325b5836150ea9cc5ae)